### PR TITLE
Add support for injecting AtriumFileHandler into AtriumSDK and also implement additional file ops

### DIFF
--- a/sdk/atriumdb/adb_functions.py
+++ b/sdk/atriumdb/adb_functions.py
@@ -1158,14 +1158,14 @@ def delete_unreferenced_tsc_files(sdk):
     del files
 
     # walk the tsc directory looking for files to delete (os.walk is a generator for memory efficiency)
-    for root, _, files in os.walk(sdk.file_api.top_level_dir):
+    for root, _, files in sdk.file_api.walk(sdk.file_api.top_level_dir):
         # check if there is a match between any of the tsc file names to be deleted and files in the current directory
         matches = set(files) & file_names
 
         # if you find a match remove the file from disk
         for m in matches:
             print(f"Deleting tsc file {m} from disk")
-            os.remove(os.path.join(root, m))
+            sdk.file_api.remove(os.path.join(root, m))
 
     # free up memory
     del file_names

--- a/sdk/atriumdb/atrium_sdk.py
+++ b/sdk/atriumdb/atrium_sdk.py
@@ -101,7 +101,7 @@ class AtriumSDK:
     :param str tsc_file_location: A file path pointing to the directory in which the TSC (time series compression) files are written for this dataset. Used to customize the TSC directory location, rather than using `dataset_location/tsc`.
     :param str atriumdb_lib_path: A file path pointing to the shared library (CDLL) that powers the compression and decompression. Not required for most users.
     :param bool no_pool: If true disables Mariadb connection pooling, instead using a new connection for each query.
-
+    :param AtriumFileHandler file_api: allow injection of file_api.
     Examples:
     -----------
     Simple Usage:
@@ -133,7 +133,7 @@ class AtriumSDK:
     def __init__(self, dataset_location: Union[str, PurePath] = None, metadata_connection_type: str = None,
                  connection_params: dict = None, num_threads: int = 1, api_url: str = None, token: str = None,
                  refresh_token=None, validate_token=True, tsc_file_location: str = None, atriumdb_lib_path: str = None,
-                 no_pool=False):
+                 no_pool=False, file_api: AtriumFileHandler = None):
 
         self.dataset_location = dataset_location
 
@@ -181,7 +181,7 @@ class AtriumSDK:
             # Initialize the SQLiteHandler with the database file path
             self.sql_handler = SQLiteHandler(db_file)
             self.mode = "local"
-            self.file_api = AtriumFileHandler(tsc_file_location)
+            self.file_api = file_api if file_api else AtriumFileHandler(tsc_file_location)
             self.settings_dict = self._get_all_settings()
 
         # Handle MySQL or MariaDB connections
@@ -209,7 +209,7 @@ class AtriumSDK:
             # Initialize the MariaDBHandler with the connection parameters
             self.sql_handler = MariaDBHandler(host, user, password, database, port, no_pool=no_pool)
             self.mode = "local"
-            self.file_api = AtriumFileHandler(tsc_file_location)
+            self.file_api = file_api if file_api else AtriumFileHandler(tsc_file_location)
             self.settings_dict = self._get_all_settings()
 
         # Handle API connections

--- a/sdk/atriumdb/atrium_sdk.py
+++ b/sdk/atriumdb/atrium_sdk.py
@@ -938,7 +938,7 @@ class AtriumSDK:
 
             # remove the tsc file from disk if it is no longer needed
             if old_tsc_file_name is not None:
-                os.remove(self.file_api.to_abs_path(filename=old_tsc_file_name, measure_id=measure_id, device_id=device_id))
+                self.file_api.remove(self.file_api.to_abs_path(filename=old_tsc_file_name, measure_id=measure_id, device_id=device_id))
 
         # If data was overwritten
         elif overwrite_file_dict is not None:

--- a/sdk/atriumdb/file_api.py
+++ b/sdk/atriumdb/file_api.py
@@ -14,7 +14,7 @@
 #
 #     You should have received a copy of the GNU General Public License
 #     along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
+import os
 from pathlib import Path
 import uuid
 import numpy as np
@@ -141,3 +141,9 @@ class AtriumFileHandler:
         writable_file_bytes = np.frombuffer(file_bytes, dtype=np.uint8).copy()
 
         return writable_file_bytes
+    def remove(self, file_path:str ):
+        # rm file
+        os.remove(file_path)
+    def walk(self, root_path: str):
+        # Directory tree generator
+        return os.walk(root_path)


### PR DESCRIPTION
Currently, overriding AtriumFileHandler is not supported by AtriumSDK.
A possible (alreday implemented and used) AtriumFileHandler override maintain atriumdb storage on slow hdd and cache
 some of the files in a fast storage (ssd).
Currently this is not fully supported due to:
1. No nice way to inject AtriumFileHandler into AtriumSDK. This pull request adds an optional file_api argument to AtriumSDK initializer.
2. Some file operations done by AtriumSDK do not go thru AtriumFileHandler, e.g., os.remove(), os.walk() and thus may not be in sync with AtriumFileHandler implementation. This pull request add these methods to AtriumFileHandler and modify the callers to use the AtriumFileHandler implementation