### PR TITLE
Use `MARIA_DB_PORT` environment variable in SDK tests

### DIFF
--- a/sdk/tests/testing_framework.py
+++ b/sdk/tests/testing_framework.py
@@ -39,7 +39,13 @@ def _test_for_both(db_name, test_function, *args):
 
     db_type = 'mariadb'
     shutil.rmtree(maria_dataset_path, ignore_errors=True)
-    maria_handler = MariaDBHandler(host, user, password, db_name)
+    maria_handler = MariaDBHandler(
+        host=host,
+        user=user,
+        password=password,
+        database=db_name,
+        port=port,
+    )
     connection_params = {
         'sqltype': db_type,
         'host': host,


### PR DESCRIPTION
Fixes #10 

- Pass the port to `MariaDBHandler` in `testing_framework._test_for_both`. I've tested this locally and can connect to MariaDB on running on a non-default port.