### PR TITLE
Add GET /measures/hours endpoint — total coverage hours per measure

### DIFF
--- a/sdk/atriumdb/dashboard/measure_queries.py
+++ b/sdk/atriumdb/dashboard/measure_queries.py
@@ -1,0 +1,185 @@
+# AtriumDB is a timeseries database software designed to best handle the unique features and
+# challenges that arise from clinical waveform data.
+#     Copyright (C) 2023  The Hospital for Sick Children
+#
+#     This program is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This program is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Dashboard-layer helpers for measure-level coverage statistics.
+
+This module provides ``query_measure_total_hours``, which aggregates
+``interval_index`` rows across all devices and returns the total wall-clock
+hours of data stored per measure.
+
+``interval_index`` holds one row per ``(measure_id, device_id)`` pair. Rows
+within a pair are non-overlapping by the SDK's write invariant, so a plain
+``SUM(end_time_n - start_time_n) GROUP BY measure_id`` gives an accurate
+device-additive total without any double-counting within a single stream.
+
+Only runs in direct-DB mode (``metadata_connection_type`` of ``"sqlite"``,
+``"mysql"``, or ``"mariadb"``).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from atriumdb import AtriumSDK
+
+logger = logging.getLogger(__name__)
+
+_NS_PER_HOUR = 3_600_000_000_000
+
+_MEASURE_TOTAL_HOURS_SQL = """
+    SELECT
+        m.id                                                        AS measure_id,
+        m.measure_tag,
+        m.freq_nhz,
+        m.units,
+        COUNT(DISTINCT ii.device_id)                                AS num_devices,
+        SUM(ii.end_time_n - ii.start_time_n)                       AS total_ns
+    FROM interval_index ii
+    JOIN measures m ON m.id = ii.measure_id
+    GROUP BY ii.measure_id
+    ORDER BY total_ns DESC
+"""
+
+_MEASURE_TOTAL_HOURS_KEYS = (
+    "measure_id",
+    "measure_tag",
+    "freq_nhz",
+    "units",
+    "num_devices",
+    "total_ns",
+)
+
+
+def query_measure_total_hours(sdk: "AtriumSDK") -> list[dict]:
+    """Return total wall-clock hours of coverage per measure across all devices.
+
+    Queries ``interval_index`` (the SDK-maintained continuous-coverage table)
+    and collapses every ``(measure_id, device_id)`` pair into a single
+    measure-level total by grouping exclusively on ``measure_id``.
+
+    ``interval_index`` must be populated (the default). If the dataset was
+    ingested with ``interval_index_mode="disable"`` this function returns an
+    empty list. See :func:`query_measure_total_hours_from_blocks` for a
+    fallback that reads ``block_index`` instead.
+
+    :param sdk: AtriumSDK instance in direct-DB mode.
+    :return: List of dicts, one per measure that has at least one interval,
+        ordered by ``total_ns`` descending::
+
+            {
+                "measure_id":  int,
+                "measure_tag": str | None,
+                "freq_nhz":    int,
+                "units":       str | None,
+                "num_devices": int,   # distinct devices that recorded this measure
+                "total_ns":    int,   # total nanoseconds of coverage
+                "total_hours": float, # total_ns / 3_600_000_000_000
+            }
+    """
+    with sdk.sql_handler.connection(begin=False) as (conn, cursor):
+        cursor.execute(_MEASURE_TOTAL_HOURS_SQL)
+        rows = cursor.fetchall()
+
+    result = []
+    for row in rows:
+        entry = dict(zip(_MEASURE_TOTAL_HOURS_KEYS, row))
+        entry["total_hours"] = (entry["total_ns"] or 0) / _NS_PER_HOUR
+        result.append(entry)
+
+    logger.debug("query_measure_total_hours: returned %d measures", len(result))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Fallback: block_index
+# ---------------------------------------------------------------------------
+
+_BLOCK_TOTAL_HOURS_SQL = """
+    SELECT
+        m.id                                                        AS measure_id,
+        m.measure_tag,
+        m.measure_name,
+        m.freq_nhz,
+        m.units,
+        COUNT(DISTINCT bi.device_id)                                AS num_devices,
+        COUNT(*)                                                    AS num_blocks,
+        SUM(bi.num_values)                                          AS total_samples,
+        SUM(bi.end_time_n - bi.start_time_n)                       AS total_ns
+    FROM block_index bi
+    JOIN measures m ON m.id = bi.measure_id
+    GROUP BY bi.measure_id
+    ORDER BY total_ns DESC
+"""
+
+_BLOCK_TOTAL_HOURS_KEYS = (
+    "measure_id",
+    "measure_tag",
+    "measure_name",
+    "freq_nhz",
+    "units",
+    "num_devices",
+    "num_blocks",
+    "total_samples",
+    "total_ns",
+)
+
+
+def query_measure_total_hours_from_blocks(sdk: "AtriumSDK") -> list[dict]:
+    """Fallback variant that reads ``block_index`` instead of ``interval_index``.
+
+    Use this when ``interval_index`` is disabled or known to be stale. The
+    result shape is the same as :func:`query_measure_total_hours` with two
+    extra keys: ``num_blocks`` (replaces ``num_intervals``) and
+    ``total_samples`` (sum of ``block_index.num_values``).
+
+    Note: ``total_hours`` counts wall-clock span of each block including any
+    intra-block gaps. ``total_samples`` counts only the actual recorded
+    data points. They diverge when signals have internal gaps encoded in the
+    TSC file.
+
+    :param sdk: AtriumSDK instance in direct-DB mode.
+    :return: List of dicts, one per measure, ordered by ``total_ns`` descending::
+
+            {
+                "measure_id":    int,
+                "measure_tag":   str | None,
+                "measure_name":  str | None,
+                "freq_nhz":      int,
+                "units":         str | None,
+                "num_devices":   int,
+                "num_blocks":    int,
+                "total_samples": int,
+                "total_ns":      int,
+                "total_hours":   float,
+            }
+    """
+    with sdk.sql_handler.connection(begin=False) as (conn, cursor):
+        cursor.execute(_BLOCK_TOTAL_HOURS_SQL)
+        rows = cursor.fetchall()
+
+    result = []
+    for row in rows:
+        entry = dict(zip(_BLOCK_TOTAL_HOURS_KEYS, row))
+        entry["total_hours"] = (entry["total_ns"] or 0) / _NS_PER_HOUR
+        result.append(entry)
+
+    logger.debug(
+        "query_measure_total_hours_from_blocks: returned %d measures", len(result)
+    )
+    return result

--- a/sdk/docs/dashboard/measure_total_hours.md
+++ b/sdk/docs/dashboard/measure_total_hours.md
@@ -114,38 +114,30 @@ ORDER BY total_hours DESC;
 
 ---
 
-## Python Helper Function
+## Python Helper Functions
 
-The SDK has no built-in aggregation for this, so it needs a custom DB function following the same pattern used elsewhere in this codebase (see `atriumDB_sdk_design_step_1_v4_refined.md` — the `query_xxx(sdk, ...)` convention).
+Implemented in `sdk/atriumdb/dashboard/measure_queries.py`, following the same `query_xxx(sdk, ...)` convention used by `encounter_queries.py`.
+
+### Primary: `query_measure_total_hours`
+
+Reads `interval_index` (the SDK-maintained continuous-coverage table). This is the preferred path because `interval_index` already merges adjacent blocks into non-overlapping spans, so no deduplication is needed in Python.
 
 ```python
-def query_measure_total_hours(sdk) -> list[dict]:
-    """
-    Returns total wall-clock hours of coverage in interval_index per measure,
-    aggregated across all devices. One dict per measure_id.
-    """
-    sql = """
-        SELECT
-            m.id                                                         AS measure_id,
-            m.measure_tag,
-            m.measure_name,
-            m.freq_nhz,
-            m.units,
-            COUNT(DISTINCT ii.device_id)                                 AS num_devices,
-            COUNT(*)                                                     AS num_intervals,
-            SUM(ii.end_time_n - ii.start_time_n) / 3600000000000.0      AS total_hours
-        FROM interval_index ii
-        JOIN measures m ON m.id = ii.measure_id
-        GROUP BY ii.measure_id
-        ORDER BY total_hours DESC
-    """
-    with sdk.sql_handler.connection(begin=False) as (conn, cursor):
-        cursor.execute(sql)
-        rows = cursor.fetchall()
+from atriumdb.dashboard.measure_queries import query_measure_total_hours
 
-    keys = ["measure_id", "measure_tag", "measure_name", "freq_nhz", "units",
-            "num_devices", "num_intervals", "total_hours"]
-    return [dict(zip(keys, row)) for row in rows]
+results = query_measure_total_hours(sdk)
+for r in results:
+    print(f"{r['measure_tag']}: {r['total_hours']:.1f} h across {r['num_devices']} devices")
+```
+
+### Fallback: `query_measure_total_hours_from_blocks`
+
+Reads `block_index` instead. Use this when `interval_index` is disabled (`interval_index_mode="disable"` at ingest time) or known to be stale. Returns the same keys as the primary function plus `num_blocks` and `total_samples`.
+
+```python
+from atriumdb.dashboard.measure_queries import query_measure_total_hours_from_blocks
+
+results = query_measure_total_hours_from_blocks(sdk)
 ```
 
 ---
@@ -212,21 +204,17 @@ A per-measure variant (`/{measure_id}/hours`) is possible but unnecessary here: 
   {
     "measure_id": 1,
     "measure_tag": "HR",
-    "measure_name": "Heart Rate",
     "freq_nhz": 500000000000,
     "units": "BPM",
     "num_devices": 12,
-    "num_intervals": 340,
     "total_hours": 4821.6
   },
   {
     "measure_id": 2,
     "measure_tag": "SpO2",
-    "measure_name": "Oxygen Saturation",
     "freq_nhz": 125000000000,
     "units": "%",
     "num_devices": 10,
-    "num_intervals": 280,
     "total_hours": 3104.2
   }
 ]

--- a/sdk/docs/dashboard/measure_total_hours.md
+++ b/sdk/docs/dashboard/measure_total_hours.md
@@ -1,0 +1,255 @@
+# Calculating Total Hours per Measure in AtriumDB
+
+This document describes how to calculate the total wall-clock hours of data that exists in the database for each measure, aggregated across all patients and devices.
+
+---
+
+## Relevant Tables
+
+### `block_index`
+
+Each row in `block_index` represents one contiguous block of ingested signal data for a specific `(measure_id, device_id)` pair. The columns relevant to time coverage are:
+
+| Column | Type | Meaning |
+|---|---|---|
+| `measure_id` | INTEGER | FK to `measures.id` |
+| `device_id` | INTEGER | FK to `devices.id` |
+| `start_time_n` | BIGINT | Inclusive block start, nanoseconds since Unix epoch |
+| `end_time_n` | BIGINT | Exclusive block end, nanoseconds since Unix epoch |
+| `num_values` | BIGINT | Number of data points stored in this block |
+
+`end_time_n` is **exclusive** — the block covers `[start_time_n, end_time_n)`. The duration of one block in nanoseconds is therefore `end_time_n - start_time_n`.
+
+There is a composite index on `(measure_id, device_id, start_time_n, end_time_n)` to support efficient time-range queries.
+
+### `interval_index`
+
+`interval_index` is a coarser-grained companion table. As blocks are written, the SDK merges adjacent or abutting blocks for the same `(measure_id, device_id)` pair into continuous coverage intervals and records them here. Columns:
+
+| Column | Type | Meaning |
+|---|---|---|
+| `measure_id` | INTEGER | FK to `measures.id` |
+| `device_id` | INTEGER | FK to `devices.id` |
+| `start_time_n` | BIGINT | Continuous coverage start, nanoseconds |
+| `end_time_n` | BIGINT | Continuous coverage end, nanoseconds |
+
+Intervals within a `(measure_id, device_id)` pair are **non-overlapping** by construction — that is the SDK's invariant when inserting into `interval_index`. This makes them the natural aggregation source for total coverage.
+
+---
+
+## Why `interval_index` Is Preferred Over `block_index`
+
+Within a single `(measure_id, device_id)`, individual blocks are also non-overlapping (each ingest produces its own block). However:
+
+- `interval_index` already performs the merge — adjacent blocks that were ingested in separate calls are collapsed into a single interval, so fewer rows need to be summed.
+- Using `interval_index` avoids any edge-case concern about abutting block boundaries being counted twice.
+- The `select_intervals()` method in `sql_handler.py` is the canonical SDK API for retrieving coverage intervals, which confirms that `interval_index` is the intended table for coverage queries.
+
+Both tables give the **same total** for a well-maintained database, but `interval_index` is cleaner.
+
+---
+
+## Caveat: Device-Level vs Patient-Level Coverage
+
+Both tables store rows per `(measure_id, device_id)`, **not per patient**. A patient is linked to a device through the `device_patient` (or `device_encounter`) join table. If two devices record the same measure for the same patient concurrently, those intervals appear as separate rows in `interval_index` and will be summed independently, potentially double-counting real-world time.
+
+For a **database-wide total** (the aggregate across all devices and patients, counting physical recording time), this double-counting is typically acceptable because each device-measure stream represents a distinct source. For a **patient-de-duplicated total** (how many unique patient-hours exist), a more complex overlap-merge is needed and is out of scope for this document.
+
+---
+
+## SQL Query: Total Hours per Measure (All Devices)
+
+`interval_index` has one row per `(measure_id, device_id)` pair — not per patient and not per measure alone. To collapse all devices for the same measure into a single total, group exclusively by `measure_id`. The `SUM` then accumulates nanoseconds across every device that recorded that measure, which is the desired database-wide aggregate.
+
+```sql
+-- Total wall-clock hours covered in interval_index per measure
+-- GROUP BY measure_id collapses all (measure_id, device_id) rows
+-- into a single measure-level total.
+SELECT
+    m.measure_tag,
+    m.measure_name,
+    m.freq_nhz,
+    m.units,
+    COUNT(DISTINCT ii.device_id)                  AS num_devices,
+    COUNT(*)                                      AS num_intervals,
+    SUM(ii.end_time_n - ii.start_time_n)          AS total_ns,
+    SUM(ii.end_time_n - ii.start_time_n)
+        / 3600000000000.0                         AS total_hours
+FROM interval_index ii
+JOIN measures m ON m.id = ii.measure_id
+GROUP BY ii.measure_id
+ORDER BY total_hours DESC;
+```
+
+### Conversion factors (from nanoseconds)
+
+| Target unit | Divisor |
+|---|---|
+| Seconds | `1_000_000_000` |
+| Minutes | `60_000_000_000` |
+| Hours | `3_600_000_000_000` |
+
+---
+
+## Alternative: Using `block_index`
+
+If `interval_index` is not populated (it can be disabled at ingest time with `interval_index_mode="disable"`), fall back to `block_index`:
+
+```sql
+SELECT
+    m.measure_tag,
+    m.measure_name,
+    COUNT(*)                                      AS num_blocks,
+    SUM(bi.num_values)                            AS total_values,
+    SUM(bi.end_time_n - bi.start_time_n)          AS total_ns,
+    SUM(bi.end_time_n - bi.start_time_n)
+        / 3600000000000.0                         AS total_hours
+FROM block_index bi
+JOIN measures m ON m.id = bi.measure_id
+GROUP BY bi.measure_id
+ORDER BY total_hours DESC;
+```
+
+`num_values` vs `total_hours`: `total_hours` reflects wall-clock span including any gaps within a block; `num_values` counts actual recorded samples. They diverge when data has internal gaps (which AtriumDB encodes as gap arrays inside the block file). Use `total_hours` for coverage and `num_values` for sample-count metrics.
+
+---
+
+## Python Helper Function
+
+The SDK has no built-in aggregation for this, so it needs a custom DB function following the same pattern used elsewhere in this codebase (see `atriumDB_sdk_design_step_1_v4_refined.md` — the `query_xxx(sdk, ...)` convention).
+
+```python
+def query_measure_total_hours(sdk) -> list[dict]:
+    """
+    Returns total wall-clock hours of coverage in interval_index per measure,
+    aggregated across all devices. One dict per measure_id.
+    """
+    sql = """
+        SELECT
+            m.id                                                         AS measure_id,
+            m.measure_tag,
+            m.measure_name,
+            m.freq_nhz,
+            m.units,
+            COUNT(DISTINCT ii.device_id)                                 AS num_devices,
+            COUNT(*)                                                     AS num_intervals,
+            SUM(ii.end_time_n - ii.start_time_n) / 3600000000000.0      AS total_hours
+        FROM interval_index ii
+        JOIN measures m ON m.id = ii.measure_id
+        GROUP BY ii.measure_id
+        ORDER BY total_hours DESC
+    """
+    with sdk.sql_handler.connection(begin=False) as (conn, cursor):
+        cursor.execute(sql)
+        rows = cursor.fetchall()
+
+    keys = ["measure_id", "measure_tag", "measure_name", "freq_nhz", "units",
+            "num_devices", "num_intervals", "total_hours"]
+    return [dict(zip(keys, row)) for row in rows]
+```
+
+---
+
+## Exposing This as a FastAPI Endpoint
+
+The AtriumDB mock API server (`sdk/tests/mock_api/`) uses **FastAPI** with a `Depends(get_sdk_instance)` injection pattern. No new framework, dependency, or connection management is needed — the endpoint follows the exact same shape as the existing `GET /measures/` route in `measures_endpoints.py`.
+
+### What to add and where
+
+| File | Change |
+|---|---|
+| `tests/mock_api/measures_endpoints.py` | Add one new route `GET /measures/hours` |
+| `tests/mock_api/app.py` | No change needed — the new route sits under the existing `measures_router` already mounted at `/measures` |
+
+### New route in `measures_endpoints.py`
+
+Add this after the existing routes. No new imports are required beyond what the file already imports.
+
+```python
+@measures_router.get("/hours")
+async def get_measure_total_hours(
+        atriumdb_sdk: AtriumSDK = Depends(get_sdk_instance)):
+    """
+    Return total hours of data in interval_index for every measure,
+    aggregated across all devices.
+    """
+    sql = """
+        SELECT
+            m.id                                                         AS measure_id,
+            m.measure_tag,
+            m.measure_name,
+            m.freq_nhz,
+            m.units,
+            COUNT(DISTINCT ii.device_id)                                 AS num_devices,
+            COUNT(*)                                                     AS num_intervals,
+            SUM(ii.end_time_n - ii.start_time_n) / 3600000000000.0      AS total_hours
+        FROM interval_index ii
+        JOIN measures m ON m.id = ii.measure_id
+        GROUP BY ii.measure_id
+        ORDER BY total_hours DESC
+    """
+    with atriumdb_sdk.sql_handler.connection(begin=False) as (conn, cursor):
+        cursor.execute(sql)
+        rows = cursor.fetchall()
+
+    keys = ["measure_id", "measure_tag", "measure_name", "freq_nhz", "units",
+            "num_devices", "num_intervals", "total_hours"]
+    return [dict(zip(keys, row)) for row in rows]
+```
+
+The route intentionally does not raise `HTTPException(404)` when the result is empty — an empty list is a valid, non-error response when no data has been ingested yet.
+
+### Why `GET /measures/hours` and not `GET /measures/{measure_id}/hours`
+
+A per-measure variant (`/{measure_id}/hours`) is possible but unnecessary here: the aggregation is cheap for all measures at once, and the caller can filter the returned list client-side. Adding a per-measure variant would only make sense if the table grew large enough that returning all rows became slow.
+
+> **Route ordering note:** FastAPI matches routes top-to-bottom. `GET /measures/hours` must be registered **before** `GET /measures/{measure_id}`, otherwise FastAPI will capture the literal string `"hours"` as the `measure_id` path parameter and route to the wrong handler. In the current `measures_endpoints.py`, adding the new route before the `/{measure_id}` handler is sufficient.
+
+### Response shape
+
+```json
+[
+  {
+    "measure_id": 1,
+    "measure_tag": "HR",
+    "measure_name": "Heart Rate",
+    "freq_nhz": 500000000000,
+    "units": "BPM",
+    "num_devices": 12,
+    "num_intervals": 340,
+    "total_hours": 4821.6
+  },
+  {
+    "measure_id": 2,
+    "measure_tag": "SpO2",
+    "measure_name": "Oxygen Saturation",
+    "freq_nhz": 125000000000,
+    "units": "%",
+    "num_devices": 10,
+    "num_intervals": 280,
+    "total_hours": 3104.2
+  }
+]
+```
+
+### Calling from an external server
+
+```python
+import httpx
+
+response = httpx.get("http://<atriumdb-host>:8000/measures/hours")
+response.raise_for_status()
+
+for entry in response.json():
+    print(f"{entry['measure_tag']}: {entry['total_hours']:.1f} h across {entry['num_devices']} devices")
+```
+
+---
+
+## Key Facts to Remember
+
+- All times in AtriumDB are **nanoseconds since Unix epoch** (UTC); no time zone conversion is applied by the database layer.
+- `end_time_n` is **exclusive** in both `block_index` and `interval_index`.
+- `interval_index` rows are non-overlapping within a `(measure_id, device_id)` pair — the SDK enforces this invariant on write.
+- Blocks are linked to patients via `device_id → device_patient → patient_id`, not directly.
+- The composite index `(measure_id, device_id, start_time_n, end_time_n)` on both tables means measure-level aggregation queries run efficiently even on large datasets.

--- a/sdk/tests/mock_api/measures_endpoints.py
+++ b/sdk/tests/mock_api/measures_endpoints.py
@@ -19,9 +19,16 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException
 
 from atriumdb import AtriumSDK
+from atriumdb.dashboard.measure_queries import query_measure_total_hours
 from tests.mock_api.sdk_dependency import get_sdk_instance
 
 measures_router = APIRouter()
+
+
+@measures_router.get("/hours")
+async def get_measure_total_hours(
+        atriumdb_sdk: AtriumSDK = Depends(get_sdk_instance)):
+    return query_measure_total_hours(atriumdb_sdk)
 
 
 @measures_router.get("/")

--- a/sdk/tests/test_dashboard_api.py
+++ b/sdk/tests/test_dashboard_api.py
@@ -1,0 +1,255 @@
+# AtriumDB is a timeseries database software designed to best handle the unique features and
+# challenges that arise from clinical waveform data.
+#     Copyright (C) 2023  The Hospital for Sick Children
+#
+#     This program is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This program is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import shutil
+import time
+import threading
+from pathlib import Path
+
+import numpy as np
+import requests
+import uvicorn
+
+from atriumdb.atrium_sdk import AtriumSDK
+from atriumdb.dashboard.measure_queries import query_measure_total_hours
+from atriumdb.dashboard.schemas import (
+    AdmissionDateRange, AgeBand, CohortDefinitionRequest,
+    DemographicCohort, MrnCohort,
+)
+from tests.mock_api.app import app
+from tests.mock_api.sdk_dependency import get_sdk_instance
+
+DB_NAME = 'dashboard_api_test'
+SQLITE_DATASET_PATH = Path(__file__).parent / "test_datasets" / f"sqlite_{DB_NAME}"
+
+DB_NAME_HOURS = 'dashboard_api_hours_test'
+SQLITE_DATASET_PATH_HOURS = Path(__file__).parent / "test_datasets" / f"sqlite_{DB_NAME_HOURS}"
+HOURS_API_PORT = 8124
+
+
+def test_api_cohorts():
+    def start_server():
+        uvicorn.run(app, port=8123)
+
+    api_thread = threading.Thread(target=start_server, daemon=True)
+    api_thread.start()
+
+    shutil.rmtree(SQLITE_DATASET_PATH, ignore_errors=True)
+    _test_api_cohorts('sqlite', SQLITE_DATASET_PATH, None)
+
+
+def _test_api_cohorts(db_type, dataset_location, connection_params):
+    sdk = AtriumSDK.create_dataset(
+        dataset_location=dataset_location, database_type=db_type, connection_params=connection_params)
+
+    app.dependency_overrides[get_sdk_instance] = lambda: sdk
+
+    api_sdk = AtriumSDK(metadata_connection_type="api", api_url="http://127.0.0.1:8123", validate_token=False)
+    api_sdk.token_expiry = time.time() + 1_000_000
+
+    # --- set up location infrastructure (institution → unit → bed) ---
+    institution_id = sdk.sql_handler.insert_institution("Test Hospital")
+    unit_id = sdk.sql_handler.insert_unit(institution_id, "ICU", "icu")
+    bed_id = sdk.sql_handler.insert_bed(unit_id, "Bed 1")
+
+    ONE_YEAR_NS = 365 * 24 * 3600 * 1_000_000_000
+    admit_start_ns = 1_600_000_000_000_000_000
+    admit_end_ns   = 1_700_000_000_000_000_000
+    inside_ns      = 1_650_000_000_000_000_000  # within the admission window
+    outside_ns     = 1_500_000_000_000_000_000  # before the admission window
+
+    # patient A: male, 25 years old at admission, has in-window encounter in ICU
+    pid_a = sdk.insert_patient(mrn="MRN001", gender="M", dob=inside_ns - 25 * ONE_YEAR_NS)
+    # patient B: female, 35 years old at admission, has in-window encounter in ICU
+    pid_b = sdk.insert_patient(mrn="MRN002", gender="F", dob=inside_ns - 35 * ONE_YEAR_NS)
+    # patient C: male, but encounter is outside the admission window
+    pid_c = sdk.insert_patient(mrn="MRN003", gender="M", dob=inside_ns - 25 * ONE_YEAR_NS)
+
+    sdk.insert_encounter(patient_id=pid_a, bed_id=bed_id, start_time=inside_ns,
+                         end_time=inside_ns + ONE_YEAR_NS, visit_number="V001")
+    sdk.insert_encounter(patient_id=pid_b, bed_id=bed_id,
+                         start_time=inside_ns + ONE_YEAR_NS // 2,
+                         end_time=inside_ns + ONE_YEAR_NS, visit_number="V002")
+    sdk.insert_encounter(patient_id=pid_c, bed_id=bed_id, start_time=outside_ns,
+                         end_time=outside_ns + ONE_YEAR_NS, visit_number="V003")
+
+    date_range = AdmissionDateRange(start=admit_start_ns, end=admit_end_ns)
+
+    print("Testing 1A: MRN cohort endpoint...")
+
+    request_1a = CohortDefinitionRequest(
+        type="mrn",
+        admission_date_range=date_range,
+        cohorts=[MrnCohort(id="cohort_1a", mrn_list=["MRN001", "MRN002", "MRN003", "MRN999"])],
+    )
+
+    # MRN001 and MRN002 have in-window encounters; MRN003 is outside the window; MRN999 does not exist
+    local_result = sdk.dashboard_resolve_cohort(request_1a, request_id="test-1a-local")
+    assert local_result.request_id == "test-1a-local"
+    assert len(local_result.cohorts) == 1
+    assert local_result.cohorts[0].id == "cohort_1a"
+    assert set(local_result.cohorts[0].mrn_list) == {"MRN001", "MRN002"}
+
+    api_result = api_sdk.dashboard_resolve_cohort(request_1a, request_id="test-1a-api")
+    assert set(api_result.cohorts[0].mrn_list) == {"MRN001", "MRN002"}
+
+    print("Testing 1B: demographic cohort — location filter...")
+
+    request_1b_loc = CohortDefinitionRequest(
+        type="demographic",
+        admission_date_range=date_range,
+        cohorts=[DemographicCohort(id="cohort_1b_loc", location=["ICU"])],
+    )
+
+    # both in-window patients are in ICU; MRN003 is outside the window
+    local_result = sdk.dashboard_resolve_cohort(request_1b_loc)
+    assert set(local_result.cohorts[0].mrn_list) == {"MRN001", "MRN002"}
+
+    api_result = api_sdk.dashboard_resolve_cohort(request_1b_loc)
+    assert set(api_result.cohorts[0].mrn_list) == {"MRN001", "MRN002"}
+
+    print("Testing 1B: demographic cohort — sex filter...")
+
+    request_1b_sex = CohortDefinitionRequest(
+        type="demographic",
+        admission_date_range=date_range,
+        cohorts=[DemographicCohort(id="cohort_1b_sex", location=["ICU"], sex=["M"])],
+    )
+
+    local_result = sdk.dashboard_resolve_cohort(request_1b_sex)
+    assert set(local_result.cohorts[0].mrn_list) == {"MRN001"}
+
+    api_result = api_sdk.dashboard_resolve_cohort(request_1b_sex)
+    assert set(api_result.cohorts[0].mrn_list) == {"MRN001"}
+
+    print("Testing 1B: demographic cohort — age filter...")
+
+    # patient A is 25 years old at admission → falls in [20, 30]; patient B is 35 → does not
+    request_1b_age = CohortDefinitionRequest(
+        type="demographic",
+        admission_date_range=date_range,
+        cohorts=[DemographicCohort(
+            id="cohort_1b_age",
+            location=["ICU"],
+            age=[AgeBand(start_ns=20 * ONE_YEAR_NS, end_ns=30 * ONE_YEAR_NS)],
+        )],
+    )
+
+    local_result = sdk.dashboard_resolve_cohort(request_1b_age)
+    assert set(local_result.cohorts[0].mrn_list) == {"MRN001"}
+
+    api_result = api_sdk.dashboard_resolve_cohort(request_1b_age)
+    assert set(api_result.cohorts[0].mrn_list) == {"MRN001"}
+
+    print("Testing 1B: demographic cohort — multiple cohorts in one request...")
+
+    request_multi = CohortDefinitionRequest(
+        type="demographic",
+        admission_date_range=date_range,
+        cohorts=[
+            DemographicCohort(id="male_icu",  location=["ICU"], sex=["M"]),
+            DemographicCohort(id="female_icu", location=["ICU"], sex=["F"]),
+        ],
+    )
+
+    local_result = sdk.dashboard_resolve_cohort(request_multi)
+    assert len(local_result.cohorts) == 2
+    cohorts_by_id = {c.id: set(c.mrn_list) for c in local_result.cohorts}
+    assert cohorts_by_id["male_icu"] == {"MRN001"}
+    assert cohorts_by_id["female_icu"] == {"MRN002"}
+
+    api_result = api_sdk.dashboard_resolve_cohort(request_multi)
+    cohorts_by_id = {c.id: set(c.mrn_list) for c in api_result.cohorts}
+    assert cohorts_by_id["male_icu"] == {"MRN001"}
+    assert cohorts_by_id["female_icu"] == {"MRN002"}
+
+    api_sdk.close()
+
+
+def test_api_measure_total_hours():
+    def start_server():
+        uvicorn.run(app, port=HOURS_API_PORT)
+
+    api_thread = threading.Thread(target=start_server, daemon=True)
+    api_thread.start()
+
+    shutil.rmtree(SQLITE_DATASET_PATH_HOURS, ignore_errors=True)
+    _test_api_measure_total_hours('sqlite', SQLITE_DATASET_PATH_HOURS, None)
+
+
+def _test_api_measure_total_hours(db_type, dataset_location, connection_params):
+    sdk = AtriumSDK.create_dataset(
+        dataset_location=dataset_location, database_type=db_type, connection_params=connection_params)
+
+    app.dependency_overrides[get_sdk_instance] = lambda: sdk
+
+    # --- create measures and devices ---
+    hr_id = sdk.insert_measure(measure_tag="HR", freq=1, freq_units="Hz", unit="BPM")
+    spo2_id = sdk.insert_measure(measure_tag="SpO2", freq=1, freq_units="Hz", unit="%")
+    dev1_id = sdk.insert_device(device_tag="monitor_1")
+    dev2_id = sdk.insert_device(device_tag="monitor_2")
+
+    # Use a fixed base timestamp (seconds) to keep numbers predictable.
+    base_s = 1_700_000_000
+
+    # HR on device 1: 7200 samples at 1 Hz → 2 hours
+    t_hr_d1 = np.arange(base_s, base_s + 7200, dtype=np.int64)
+    v_hr_d1 = np.zeros(7200, dtype=np.float64)
+    sdk.write_data_easy(hr_id, dev1_id, t_hr_d1, v_hr_d1, freq=1, freq_units="Hz", time_units="s")
+
+    # HR on device 2: 3600 samples at 1 Hz → 1 hour
+    t_hr_d2 = np.arange(base_s, base_s + 3600, dtype=np.int64)
+    v_hr_d2 = np.zeros(3600, dtype=np.float64)
+    sdk.write_data_easy(hr_id, dev2_id, t_hr_d2, v_hr_d2, freq=1, freq_units="Hz", time_units="s")
+
+    # SpO2 on device 1: 3600 samples at 1 Hz → 1 hour
+    t_spo2_d1 = np.arange(base_s, base_s + 3600, dtype=np.int64)
+    v_spo2_d1 = np.zeros(3600, dtype=np.float64)
+    sdk.write_data_easy(spo2_id, dev1_id, t_spo2_d1, v_spo2_d1, freq=1, freq_units="Hz", time_units="s")
+
+    print("Testing measure_total_hours: local helper...")
+
+    local_result = query_measure_total_hours(sdk)
+    assert len(local_result) == 2
+
+    by_tag = {r["measure_tag"]: r for r in local_result}
+
+    assert set(by_tag["HR"].keys()) == {"measure_id", "measure_tag", "freq_nhz", "units",
+                                        "num_devices", "total_ns", "total_hours"}
+    assert abs(by_tag["HR"]["total_hours"] - 3.0) < 1e-6
+    assert by_tag["HR"]["num_devices"] == 2
+    assert abs(by_tag["SpO2"]["total_hours"] - 1.0) < 1e-6
+    assert by_tag["SpO2"]["num_devices"] == 1
+
+    print("Testing measure_total_hours: API endpoint GET /measures/hours...")
+
+    # Give the server a moment to be ready.
+    time.sleep(0.5)
+
+    resp = requests.get(f"http://127.0.0.1:{HOURS_API_PORT}/measures/hours", timeout=10)
+    assert resp.status_code == 200
+
+    api_result = resp.json()
+    assert len(api_result) == 2
+
+    by_tag_api = {r["measure_tag"]: r for r in api_result}
+
+    assert abs(by_tag_api["HR"]["total_hours"] - 3.0) < 1e-6
+    assert by_tag_api["HR"]["num_devices"] == 2
+    assert abs(by_tag_api["SpO2"]["total_hours"] - 1.0) < 1e-6
+    assert by_tag_api["SpO2"]["num_devices"] == 1
+
+    print("All measure_total_hours tests passed.")


### PR DESCRIPTION
Adds a dashboard-layer query function and a FastAPI endpoint that returns the total wall-clock hours of data stored in `interval_index` for each measure, aggregated across all devices.

**Changes**
- atriumdb/dashboard/measure_queries.py — new query_measure_total_hours(sdk) helper (primary, reads interval_index) and query_measure_total_hours_from_blocks(sdk) fallback (reads block_index when interval_index is disabled)
- tests/mock_api/measures_endpoints.py — new GET /measures/hours route wired into the existing measures_router
- tests/test_dashboard_api.py — unit tests covering both the local helper and the HTTP endpoint with a synthetic SQLite dataset
- docs/dashboard/measure_total_hours.md — design notes on the block_index/interval_index schema and the aggregation approach

**Response shape**
```
[{ "measure_id", "measure_tag", "freq_nhz", "units", "num_devices", "total_ns", "total_hours" }]
```
Ordered by total_hours descending.

---
**Action items before merge**

- [ ] Run query_measure_total_hours against the real SickKids dataset and spot-check a few measures — verify total_hours and num_devices values are plausible against known recording volumes
